### PR TITLE
set property-sort-order to default alphabetical sorting

### DIFF
--- a/scss-lint.yml
+++ b/scss-lint.yml
@@ -89,7 +89,6 @@ linters:
 
   PropertySortOrder:
     enabled: true
-    order: concentric
 
   PropertySpelling:
     enabled: true


### PR DESCRIPTION
Get rid of the current _concentric_ sorting order to allow default alphabetical sorting.
