### PR TITLE
remove rule

### DIFF
--- a/eslintrc
+++ b/eslintrc
@@ -51,6 +51,7 @@
       "no-unreachable": 2,
       "no-undef": 2,
       "no-undef-init": 2,
+      "no-underscore-dangle": 0,
       "no-unused-expressions": 2,
       "no-octal": 2,
       "no-octal-escape": 2,


### PR DESCRIPTION
We want to use the underscore for naming private properties in our classes. This rule wasn't allowing us to do it. For example:

``` javascript
const _levels = [ 'catalunya', 'barcelona', 'sant cugat' ];

get city(){
   return _levels[3];
}
```
