### PR TITLE
updated rule ImportPath to fit behavior of new node-sass importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,9 @@ In order to avoid specificity problems using `!important` in SASS properties is 
 
 ### ImportPath
 
-An imported partials SASS file paths cannot have preceding underscores `_` and `.scss` expensions declared in path.
+An imported partials SASS file paths cannot have preceding underscores `_` but it must contain a `.scss` expension declared in path in order to be compatible with the `node-sass v.3.4.1`.
+
+This update to `node-sass` is mandatory to execute this package under Node v.4.
 
 **Bad**
 

--- a/scss-lint.yml
+++ b/scss-lint.yml
@@ -61,7 +61,7 @@ linters:
   ImportPath:
     enabled: true
     leading_underscore: false
-    filename_extension: false
+    filename_extension: true
 
   Indentation:
     enabled: true


### PR DESCRIPTION
### Included in this PR:

Updating _sui-components_ to `node-sass v.3.4.1` throws the following error when trying to publish to **npm**:

```
Error: It's not clear which file to import for '@import:
   ../node_modules/@schibstedspain/sui-card/dist/sui-card
   ../node_modules/@schibstedspain/sui-card/dist/_sui-card.scss
   ../node_modules/@schibstedspain/sui-card/dist/sui-card.css
```

The new `node-sass` doesn't know which file has to import if no extension is provided. This is why I've set the rule `ImportPath: filename_extension: true`.

We need to have compatibility with Node 4
Please review
