### PR TITLE
added avoid-escape to rule quotes

### DIFF
--- a/eslintrc
+++ b/eslintrc
@@ -86,7 +86,7 @@
       "max-depth": [0, 4],
       "new-cap": 2,
       "new-parens": 2,
-      "quotes": [2, "single"],
+      "quotes": [2, "single", "avoid-escape"],
       "quote-props": 0,
       "radix": 2,
       "semi": 2,


### PR DESCRIPTION
### Included in this PR:
- Added `avoid-escape` attribute to rule **quotes** to enable double quotes only inside a string that otherwise needs to be escaped.

You can review the quotes documentation page [here](http://eslint.org/docs/rules/quotes.html).

This PR fixes the [following issue](https://github.com/SUI-Components/frontend-pre-commit-rules/issues/18)

Please review @ruben-martin-lozano @danderu @nucliweb @carlosvillu @vincepal 
