### PR TITLE
Remove react-jsx

### DIFF
--- a/eslintrc
+++ b/eslintrc
@@ -27,6 +27,7 @@
       "objectLiteralComputedProperties": true
     },
     "rules": {
+      "jsx-quotes": [2, "prefer-single"],
       "no-alert": 2,
       "no-array-constructor": 2,
       "no-caller": 2,
@@ -98,7 +99,6 @@
       "wrap-regex": 0,
 
       "react/display-name": 0,
-      "react/jsx-quotes": [2, "prefer-single"],
       "react/jsx-no-undef": 1,
       "react/jsx-uses-react": 1,
       "react/jsx-uses-vars": 1,


### PR DESCRIPTION
I'm changing "react/jsx-quotes": [2, "prefer-single"], rule, since it is deprecated and not supported anymore by the latest version of eslint. I'm adding the "jsx-quotes" rule instead.

This change in eslinte is due to jsx is not a react-only syntax anymore (it's supported in cycle.js, as well)

@davecarter @carlosvillu @nucliweb please review
