### PR TITLE
fix(script) Windows is ignoring env execution with node

### DIFF
--- a/packages/frontend-pre-commit-rules/package.json
+++ b/packages/frontend-pre-commit-rules/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "install": "./install.js"
+    "install": "node ./install.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Use node executable on the package.json in order to make it compatible with Windows, otherwise it doesn't understand the environment execution. It ignores the `#!/usr/bin/env node`.